### PR TITLE
Customize the map style

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -22,6 +22,7 @@ function HomePage() {
       map = new google.maps.Map(googlemap.current, {
         center: {lat: 35.011636, lng: 135.768029}, // Kyoto (https://www.countrycoordinate.com/city-kyoto-japan/)
         zoom: 17,
+        mapId: '83a67631594fbfff',
         // Disable the default UI control buttons
         fullscreenControl: false,
         mapTypeControl: false,


### PR DESCRIPTION
- Remove all the default buttons
- Render the map in the custom style created with Google Maps's cloud-based style editor

For this to work with Percy, the custom style needs to be in the raster format, not in the vector format which relies on WebGL which headless Chromium (on which Percy relies) cannot render.