### PR TITLE
Refactor Button styled component with CSS variables

### DIFF
--- a/src/components/LocatorButton.js
+++ b/src/components/LocatorButton.js
@@ -8,14 +8,14 @@ import SvgCloud from 'src/elements/SvgCloud';
 
 const LocatorButton = () => {
   const nightMode = useContext(NightModeContext);
-  return nightMode ? (
-    <Button.Nighttime data-position="bottom-right-second" type="button">
+  return (
+    <Button
+      data-darkmode={nightMode}
+      data-position="bottom-right-second"
+      type="button"
+    >
       <SvgCloud icon="flightTakeoff" title="Show current location" />
-    </Button.Nighttime>
-  ) : (
-    <Button.Daytime data-position="bottom-right-second" type="button">
-      <SvgCloud icon="flightTakeoff" title="Show current location" />
-    </Button.Daytime>
+    </Button>
   );
 };
 

--- a/src/components/LocatorButton.stories.js
+++ b/src/components/LocatorButton.stories.js
@@ -18,22 +18,30 @@ export default {
   },
 };
 
+// Day mode
+function LocatorButtonAtDay() {
+  return (
+    <NightModeContext.Provider value={false}>
+      <LocatorButton />
+    </NightModeContext.Provider>
+  );
+}
 export function DefaultStyle() {
-  return <LocatorButton />;
+  return <LocatorButtonAtDay />;
 }
 
 export function FocusStyle() {
-  return <LocatorButton />;
+  return <LocatorButtonAtDay />;
 }
 FocusStyle.parameters = {pseudo: {focus: true}};
 
 export function HoverStyle() {
-  return <LocatorButton />;
+  return <LocatorButtonAtDay />;
 }
 HoverStyle.parameters = {pseudo: {hover: true}};
 
 export function ActiveStyle() {
-  return <LocatorButton />;
+  return <LocatorButtonAtDay />;
 }
 ActiveStyle.parameters = {pseudo: {active: true}};
 

--- a/src/components/LocatorButton.test.js
+++ b/src/components/LocatorButton.test.js
@@ -4,7 +4,6 @@ import {axe} from 'jest-axe';
 
 import LocatorButton from './LocatorButton';
 import {NightModeContext} from 'src/context/NightModeContext';
-import {color} from 'src/utils/designtokens';
 
 const accessibleName = 'Show current location';
 const mockProps = {};
@@ -20,21 +19,6 @@ const Wrapper = {
     </NightModeContext.Provider>
   ),
 };
-
-describe('Dark mode checks', () => {
-  test('renders Light mode', () => {
-    render(<LocatorButton {...mockProps} />, {wrapper: Wrapper.lightMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['dark-grey 100']};
-    `);
-  });
-  test('renders Dark mode', () => {
-    render(<LocatorButton {...mockProps} />, {wrapper: Wrapper.darkMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['off-white 100']};
-    `);
-  });
-});
 
 describe('HTML checks', () => {
   beforeEach(() => {

--- a/src/components/MenuButton.js
+++ b/src/components/MenuButton.js
@@ -8,14 +8,10 @@ import SvgCloud from 'src/elements/SvgCloud';
 
 const MenuButton = () => {
   const nightMode = useContext(NightModeContext);
-  return nightMode ? (
-    <Button.Nighttime data-position="top-left" type="button">
+  return (
+    <Button data-darkmode={nightMode} data-position="top-left" type="button">
       <SvgCloud icon="menu" title="Show menu" />
-    </Button.Nighttime>
-  ) : (
-    <Button.Daytime data-position="top-left" type="button">
-      <SvgCloud icon="menu" title="Show menu" />
-    </Button.Daytime>
+    </Button>
   );
 };
 

--- a/src/components/MenuButton.stories.js
+++ b/src/components/MenuButton.stories.js
@@ -18,22 +18,31 @@ export default {
   },
 };
 
+// Day mode
+function MenuButtonAtDay() {
+  return (
+    <NightModeContext.Provider value={false}>
+      <MenuButton />
+    </NightModeContext.Provider>
+  );
+}
+
 export function DefaultStyle() {
-  return <MenuButton />;
+  return <MenuButtonAtDay />;
 }
 
 export function FocusStyle() {
-  return <MenuButton />;
+  return <MenuButtonAtDay />;
 }
 FocusStyle.parameters = {pseudo: {focus: true}};
 
 export function HoverStyle() {
-  return <MenuButton />;
+  return <MenuButtonAtDay />;
 }
 HoverStyle.parameters = {pseudo: {hover: true}};
 
 export function ActiveStyle() {
-  return <MenuButton />;
+  return <MenuButtonAtDay />;
 }
 ActiveStyle.parameters = {pseudo: {active: true}};
 

--- a/src/components/MenuButton.test.js
+++ b/src/components/MenuButton.test.js
@@ -4,7 +4,6 @@ import {axe} from 'jest-axe';
 
 import MenuButton from './MenuButton';
 import {NightModeContext} from 'src/context/NightModeContext';
-import {color} from 'src/utils/designtokens';
 
 const accessibleName = 'Show menu';
 const mockProps = {};
@@ -20,21 +19,6 @@ const Wrapper = {
     </NightModeContext.Provider>
   ),
 };
-
-describe('Dark mode checks', () => {
-  test('renders Light mode', () => {
-    render(<MenuButton {...mockProps} />, {wrapper: Wrapper.lightMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['dark-grey 100']};
-    `);
-  });
-  test('renders Dark mode', () => {
-    render(<MenuButton {...mockProps} />, {wrapper: Wrapper.darkMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['off-white 100']};
-    `);
-  });
-});
 
 describe('HTML checks', () => {
   beforeEach(() => {

--- a/src/components/SavePlaceButton.js
+++ b/src/components/SavePlaceButton.js
@@ -8,14 +8,14 @@ import SvgCloud from 'src/elements/SvgCloud';
 
 const SavePlaceButton = () => {
   const nightMode = useContext(NightModeContext);
-  return nightMode ? (
-    <Button.Nighttime data-position="bottom-right" type="button">
+  return (
+    <Button
+      data-darkmode={nightMode}
+      data-position="bottom-right"
+      type="button"
+    >
       <SvgCloud icon="add" title="Save a place" />
-    </Button.Nighttime>
-  ) : (
-    <Button.Daytime data-position="bottom-right" type="button">
-      <SvgCloud icon="add" title="Save a place" />
-    </Button.Daytime>
+    </Button>
   );
 };
 

--- a/src/components/SavePlaceButton.stories.js
+++ b/src/components/SavePlaceButton.stories.js
@@ -18,22 +18,31 @@ export default {
   },
 };
 
+// Night mode
+function SavePlaceButtonAtDay() {
+  return (
+    <NightModeContext.Provider value={false}>
+      <SavePlaceButton />
+    </NightModeContext.Provider>
+  );
+}
+
 export function DefaultStyle() {
-  return <SavePlaceButton />;
+  return <SavePlaceButtonAtDay />;
 }
 
 export function FocusStyle() {
-  return <SavePlaceButton />;
+  return <SavePlaceButtonAtDay />;
 }
 FocusStyle.parameters = {pseudo: {focus: true}};
 
 export function HoverStyle() {
-  return <SavePlaceButton />;
+  return <SavePlaceButtonAtDay />;
 }
 HoverStyle.parameters = {pseudo: {hover: true}};
 
 export function ActiveStyle() {
-  return <SavePlaceButton />;
+  return <SavePlaceButtonAtDay />;
 }
 ActiveStyle.parameters = {pseudo: {active: true}};
 

--- a/src/components/SavePlaceButton.test.js
+++ b/src/components/SavePlaceButton.test.js
@@ -4,7 +4,6 @@ import {axe} from 'jest-axe';
 
 import SavePlaceButton from './SavePlaceButton';
 import {NightModeContext} from 'src/context/NightModeContext';
-import {color} from 'src/utils/designtokens';
 
 const accessibleName = 'Save a place';
 const mockProps = {};
@@ -20,21 +19,6 @@ const Wrapper = {
     </NightModeContext.Provider>
   ),
 };
-
-describe('Dark mode checks', () => {
-  test('renders Light mode', () => {
-    render(<SavePlaceButton {...mockProps} />, {wrapper: Wrapper.lightMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['dark-grey 100']};
-    `);
-  });
-  test('renders Dark mode', () => {
-    render(<SavePlaceButton {...mockProps} />, {wrapper: Wrapper.darkMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['off-white 100']};
-    `);
-  });
-});
 
 describe('HTML checks', () => {
   beforeEach(() => {

--- a/src/components/SearchButton.js
+++ b/src/components/SearchButton.js
@@ -8,14 +8,10 @@ import SvgCloud from 'src/elements/SvgCloud';
 
 const SearchButton = () => {
   const nightMode = useContext(NightModeContext);
-  return nightMode ? (
-    <Button.Nighttime data-position="top-right" type="button">
+  return (
+    <Button data-darkmode={nightMode} data-position="top-right" type="button">
       <SvgCloud icon="search" title="Search a place" />
-    </Button.Nighttime>
-  ) : (
-    <Button.Daytime data-position="top-right" type="button">
-      <SvgCloud icon="search" title="Search a place" />
-    </Button.Daytime>
+    </Button>
   );
 };
 

--- a/src/components/SearchButton.stories.js
+++ b/src/components/SearchButton.stories.js
@@ -18,22 +18,30 @@ export default {
   },
 };
 
+// Day mode
+function SearchButtonAtDay() {
+  return (
+    <NightModeContext.Provider value={false}>
+      <SearchButton />
+    </NightModeContext.Provider>
+  );
+}
 export function DefaultStyle() {
-  return <SearchButton />;
+  return <SearchButtonAtDay />;
 }
 
 export function FocusStyle() {
-  return <SearchButton />;
+  return <SearchButtonAtDay />;
 }
 FocusStyle.parameters = {pseudo: {focus: true}};
 
 export function HoverStyle() {
-  return <SearchButton />;
+  return <SearchButtonAtDay />;
 }
 HoverStyle.parameters = {pseudo: {hover: true}};
 
 export function ActiveStyle() {
-  return <SearchButton />;
+  return <SearchButtonAtDay />;
 }
 ActiveStyle.parameters = {pseudo: {active: true}};
 

--- a/src/components/SearchButton.test.js
+++ b/src/components/SearchButton.test.js
@@ -4,7 +4,6 @@ import {axe} from 'jest-axe';
 
 import SearchButton from './SearchButton';
 import {NightModeContext} from 'src/context/NightModeContext';
-import {color} from 'src/utils/designtokens';
 
 const accessibleName = 'Search a place';
 const mockProps = {};
@@ -21,20 +20,6 @@ const Wrapper = {
   ),
 };
 
-describe('Dark mode checks', () => {
-  test('renders Light mode', () => {
-    render(<SearchButton {...mockProps} />, {wrapper: Wrapper.lightMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['dark-grey 100']};
-    `);
-  });
-  test('renders Dark mode', () => {
-    render(<SearchButton {...mockProps} />, {wrapper: Wrapper.darkMode});
-    expect(screen.getByRole('img')).toHaveStyle(`
-      fill: ${color['off-white 100']};
-    `);
-  });
-});
 describe('HTML checks', () => {
   beforeEach(() => {
     render(<SearchButton {...mockProps} />, {wrapper: Wrapper.lightMode});

--- a/src/elements/Button.js
+++ b/src/elements/Button.js
@@ -48,164 +48,91 @@ const positionButton = css`
   }
 `;
 
-const darkmode = `
+const setButtonLabelColor = css`
+  & svg {
+    fill: var(--button-label-color-default);
+  }
+  &:focus svg,
+  &:hover svg {
+    fill: var(--button-label-color-focus);
+  }
+  &:active svg {
+    fill: var(--button-label-color-default);
+  }
+`;
+const setButtonColor = css`
+  & #cloud {
+    fill: var(--button-color);
+  }
+`;
+const setButtonShadow = css`
+  & #cloud {
+    stroke: var(--button-outline-color);
+  }
+  & svg {
+    filter: drop-shadow(
+        ${dimension.shadow['offset']} ${dimension.shadow['blur layer 1']}
+          var(--button-shadow-color)
+      )
+      drop-shadow(
+        ${dimension.shadow['offset']} ${dimension.shadow['blur layer 2']}
+          var(--button-shadow-color)
+      )
+      drop-shadow(
+        ${dimension.shadow['offset']} ${dimension.shadow['blur layer 3']}
+          var(--button-shadow-color)
+      );
+  }
+  &:focus #cloud,
+  &:hover #cloud {
+    stroke: var(--button-outline-color-focus);
+  }
+  &:focus svg,
+  &:hover svg {
+    filter: drop-shadow(
+      ${dimension.glow['offset']} var(--button-shadow-blur-radius-focus)
+        var(--button-shadow-color-focus)
+    );
+  }
+  &:active svg {
+    filter: none;
+  }
+  &:active #cloud {
+    stroke: none;
+  }
+`;
+const setColorScheme = css`
   &[data-darkmode='false'] {
-    --label-color-default: ${color['dark-grey 100']};
-    --label-color-focus: ${color['black 100']};
+    --button-label-color-default: ${color['dark-grey 100']};
+    --button-label-color-focus: ${color['black 100']};
     --button-color: ${color['white 93']};
-    --outline-color: ${color['light-grey 100']};
+    --button-outline-color: ${color['light-grey 100']};
+    --button-outline-color-focus: ${color['focus-blue 100']};
+    --button-shadow-blur-radius-focus: ${dimension.glow['blur daytime']};
+    --button-shadow-color: ${color['black 33']};
+    --button-shadow-color-focus: ${color['focus-blue 100']};
   }
   &[data-darkmode='true'] {
-    --label-color-default: ${color['off-white 100']};
-    --label-color-focus: ${color['white 100']};
+    --button-label-color-default: ${color['off-white 100']};
+    --button-label-color-focus: ${color['white 100']};
     --button-color: ${color['mid-grey 80']};
-    --outline-color: ${color['off-black 100']};
+    --button-outline-color: ${color['off-black 100']};
+    --button-outline-color-focus: ${color['white 40']};
+    --button-shadow-blur-radius-focus: ${dimension.glow['blur nighttime']};
+    --button-shadow-color: ${color['black 60']};
+    --button-shadow-color-focus: ${color['white 100']};
   }
 `;
 
-const setButtonLabelColor = {
-  daytime: css`
-    & svg {
-      fill: ${color['dark-grey 100']};
-    }
-    &:focus svg,
-    &:hover svg {
-      fill: ${color['black 100']};
-    }
-    &:active svg {
-      fill: ${color['dark-grey 100']};
-    }
-  `,
-  nighttime: css`
-    & svg {
-      fill: ${color['off-white 100']};
-    }
-    &:focus svg,
-    &:hover svg {
-      fill: ${color['white 100']};
-    }
-    &:active svg {
-      fill: ${color['off-white 100']};
-    }
-  `,
-};
-const setButtonColor = {
-  daytime: css`
-    & #cloud {
-      fill: ${color['white 93']};
-    }
-  `,
-  nighttime: css`
-    & #cloud {
-      fill: ${color['mid-grey 80']};
-    }
-  `,
-};
-
-const setButtonShadow = {
-  daytime: css`
-    & #cloud {
-      stroke: ${color['light-grey 100']};
-    }
-    & svg {
-      filter: drop-shadow(
-          ${dimension.shadow['offset']} ${dimension.shadow['blur layer 1']}
-            ${color['black 33']}
-        )
-        drop-shadow(
-          ${dimension.shadow['offset']} ${dimension.shadow['blur layer 2']}
-            ${color['black 33']}
-        )
-        drop-shadow(
-          ${dimension.shadow['offset']} ${dimension.shadow['blur layer 3']}
-            ${color['black 33']}
-        );
-    }
-    &:focus #cloud,
-    &:hover #cloud {
-      stroke: ${color['focus-blue 100']};
-    }
-    &:focus svg,
-    &:hover svg {
-      filter: drop-shadow(
-        ${dimension.glow['offset']} ${dimension.glow['blur daytime']}
-          ${color['focus-blue 100']}
-      );
-    }
-    &:active svg {
-      filter: none;
-    }
-    &:active #cloud {
-      stroke: none;
-    }
-  `,
-  nighttime: css`
-    & #cloud {
-      stroke: ${color['off-black 100']};
-    }
-    & svg {
-      filter: drop-shadow(
-          ${dimension.shadow['offset']} ${dimension.shadow['blur layer 1']}
-            ${color['black 60']}
-        )
-        drop-shadow(
-          ${dimension.shadow['offset']} ${dimension.shadow['blur layer 2']}
-            ${color['black 60']}
-        )
-        drop-shadow(
-          ${dimension.shadow['offset']} ${dimension.shadow['blur layer 3']}
-            ${color['black 60']}
-        );
-    }
-    &:focus #cloud,
-    &:hover #cloud {
-      stroke: ${color['white 40']};
-    }
-    &:focus svg,
-    &:hover svg {
-      filter: drop-shadow(
-        ${dimension.glow['offset']} ${dimension.glow['blur nighttime']}
-          ${color['white 100']}
-      );
-    }
-    &:active svg {
-      filter: none;
-    }
-    &:active #cloud {
-      stroke: none;
-    }
-  `,
-};
-
-// Group CSS utilities
-const styleCloudButton = css`
+// Define Button components
+export const Button = styled.button`
   ${resetStyle}
   ${setClickableArea}
   ${alignButtonLabel}
   ${showButtonAboveMap}
   ${positionButton}
+  ${setButtonLabelColor}
+  ${setButtonColor}
+  ${setButtonShadow}
+  ${setColorScheme}
 `;
-const colorCloudButton = {
-  daytime: css`
-    ${setButtonLabelColor.daytime}
-    ${setButtonColor.daytime}
-    ${setButtonShadow.daytime}
-  `,
-  nighttime: css`
-    ${setButtonLabelColor.nighttime}
-    ${setButtonColor.nighttime}
-    ${setButtonShadow.nighttime}
-  `,
-};
-
-// Define Button components
-export const Button = {
-  Daytime: styled.button`
-    ${styleCloudButton}
-    ${colorCloudButton.daytime}
-  `,
-  Nighttime: styled.button`
-    ${styleCloudButton}
-    ${colorCloudButton.nighttime}
-  `,
-};

--- a/src/elements/Button.test.js
+++ b/src/elements/Button.test.js
@@ -4,8 +4,8 @@ import {render, screen} from '@testing-library/react';
 import {Button} from './Button';
 
 describe('Button component', () => {
-  test('renders the daytime UI correctly', () => {
-    const {container} = render(<Button.Daytime />);
+  test('renders the UI correctly', () => {
+    const {container} = render(<Button />);
     expect(container).toMatchInlineSnapshot(`
 .c0 {
   background-color: rgba(255,255,255,0);
@@ -53,40 +53,40 @@ describe('Button component', () => {
 }
 
 .c0 svg {
-  fill: rgb(90,90,90);
+  fill: var(--button-label-color-default);
 }
 
 .c0:focus svg,
 .c0:hover svg {
-  fill: rgb(3,3,3);
+  fill: var(--button-label-color-focus);
 }
 
 .c0:active svg {
-  fill: rgb(90,90,90);
+  fill: var(--button-label-color-default);
 }
 
 .c0 #cloud {
-  fill: rgba(255,255,255,0.93);
+  fill: var(--button-color);
 }
 
 .c0 #cloud {
-  stroke: rgb(148,148,148);
+  stroke: var(--button-outline-color);
 }
 
 .c0 svg {
-  -webkit-filter: drop-shadow( 0px 0px 1px rgba(3,3,3,0.33) ) drop-shadow( 0px 0px 2px rgba(3,3,3,0.33) ) drop-shadow( 0px 0px 4px rgba(3,3,3,0.33) );
-  filter: drop-shadow( 0px 0px 1px rgba(3,3,3,0.33) ) drop-shadow( 0px 0px 2px rgba(3,3,3,0.33) ) drop-shadow( 0px 0px 4px rgba(3,3,3,0.33) );
+  -webkit-filter: drop-shadow( 0px 0px 1px var(--button-shadow-color) ) drop-shadow( 0px 0px 2px var(--button-shadow-color) ) drop-shadow( 0px 0px 4px var(--button-shadow-color) );
+  filter: drop-shadow( 0px 0px 1px var(--button-shadow-color) ) drop-shadow( 0px 0px 2px var(--button-shadow-color) ) drop-shadow( 0px 0px 4px var(--button-shadow-color) );
 }
 
 .c0:focus #cloud,
 .c0:hover #cloud {
-  stroke: rgb(69,159,189);
+  stroke: var(--button-outline-color-focus);
 }
 
 .c0:focus svg,
 .c0:hover svg {
-  -webkit-filter: drop-shadow( 0px 0px 5px rgb(69,159,189) );
-  filter: drop-shadow( 0px 0px 5px rgb(69,159,189) );
+  -webkit-filter: drop-shadow( 0px 0px var(--button-shadow-blur-radius-focus) var(--button-shadow-color-focus) );
+  filter: drop-shadow( 0px 0px var(--button-shadow-blur-radius-focus) var(--button-shadow-color-focus) );
 }
 
 .c0:active svg {
@@ -98,106 +98,26 @@ describe('Button component', () => {
   stroke: none;
 }
 
-<div>
-  <button
-    class="c0"
-  />
-</div>
-`);
-  });
-
-  test('renders the nighttime UI correctly', () => {
-    const {container} = render(<Button.Nighttime />);
-    expect(container).toMatchInlineSnapshot(`
-.c0 {
-  background-color: rgba(255,255,255,0);
-  border: none;
-  height: 48px;
-  width: 56px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: absolute;
-  z-index: 1;
-  bottom: var(--bottom,auto);
-  left: var(--left,auto);
-  right: var(--right,auto);
-  top: var(--top,auto);
+.c0[data-darkmode='false'] {
+  --button-label-color-default: rgb(90,90,90);
+  --button-label-color-focus: rgb(3,3,3);
+  --button-color: rgba(255,255,255,0.93);
+  --button-outline-color: rgb(148,148,148);
+  --button-outline-color-focus: rgb(69,159,189);
+  --button-shadow-blur-radius-focus: 5px;
+  --button-shadow-color: rgba(3,3,3,0.33);
+  --button-shadow-color-focus: rgb(69,159,189);
 }
 
-.c0[data-position='top-left'] {
-  --top: 12px;
-  --left: 14px;
-}
-
-.c0[data-position='top-right'] {
-  --top: 12px;
-  --right: 14px;
-}
-
-.c0[data-position='bottom-right'] {
-  --bottom: 24px;
-  --right: 14px;
-}
-
-.c0[data-position='bottom-right-second'] {
-  --bottom: 84px;
-  --right: 14px;
-}
-
-.c0 svg {
-  fill: rgb(218,218,218);
-}
-
-.c0:focus svg,
-.c0:hover svg {
-  fill: rgb(255,255,255);
-}
-
-.c0:active svg {
-  fill: rgb(218,218,218);
-}
-
-.c0 #cloud {
-  fill: rgba(123,123,123,0.8);
-}
-
-.c0 #cloud {
-  stroke: #2b2b2b;
-}
-
-.c0 svg {
-  -webkit-filter: drop-shadow( 0px 0px 1px rgba(3,3,3,0.6) ) drop-shadow( 0px 0px 2px rgba(3,3,3,0.6) ) drop-shadow( 0px 0px 4px rgba(3,3,3,0.6) );
-  filter: drop-shadow( 0px 0px 1px rgba(3,3,3,0.6) ) drop-shadow( 0px 0px 2px rgba(3,3,3,0.6) ) drop-shadow( 0px 0px 4px rgba(3,3,3,0.6) );
-}
-
-.c0:focus #cloud,
-.c0:hover #cloud {
-  stroke: rgba(255,255,255,0.4);
-}
-
-.c0:focus svg,
-.c0:hover svg {
-  -webkit-filter: drop-shadow( 0px 0px 10px rgb(255,255,255) );
-  filter: drop-shadow( 0px 0px 10px rgb(255,255,255) );
-}
-
-.c0:active svg {
-  -webkit-filter: none;
-  filter: none;
-}
-
-.c0:active #cloud {
-  stroke: none;
+.c0[data-darkmode='true'] {
+  --button-label-color-default: rgb(218,218,218);
+  --button-label-color-focus: rgb(255,255,255);
+  --button-color: rgba(123,123,123,0.8);
+  --button-outline-color: #2b2b2b;
+  --button-outline-color-focus: rgba(255,255,255,0.4);
+  --button-shadow-blur-radius-focus: 10px;
+  --button-shadow-color: rgba(3,3,3,0.6);
+  --button-shadow-color-focus: rgb(255,255,255);
 }
 
 <div>


### PR DESCRIPTION
- Use `data-*` attributes in place of "props"
- The `data-*` attribute selectors assign values to CSS variables (e.g., dark mode or not, top-left or bottom-right, etc.)
- `Button` component itself is styled with CSS variables (e.g., `fill: var(--button-color)`)

This way, we only need one single component called `<Button>`. 
- To position top-left, we set `<Button data-position="top-left">`.
- To apply the dark mode, we set `<Button data-darkmode="true">`.

close #48