### PR TITLE
Preconnect Google Maps servers

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -7,8 +7,12 @@ export default function App({Component, pageProps}) {
   return (
     <>
       <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         {/* This tag would cause an error if it were in _document.js. See https://github.com/vercel/next.js/blob/master/errors/no-document-viewport-meta.md */}
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        {/* Google Maps server */}
+        <link rel="preconnect" href="https://maps.googleapis.com" />{' '}
+        {/* Google Fonts server */}
+        <link rel="preconnect" href="https://maps.gstatic.com" />{' '}
       </Head>
       <GlobalStyle />
       <NightModeProvider>


### PR DESCRIPTION
## Purpose
speed up the rendering of embedded Google Maps

## Motivation
To follow suggests by LightHouse audits:
<img width="678" alt="Screenshot 2021-10-07 at 13 43 29" src="https://user-images.githubusercontent.com/36348559/136321693-cfebf780-9de1-4ae5-b5f3-9838cd678831.png">

`https://maps.googleapis.com` is accessed for fetching the map data.

`https://maps.gstatic.com` is accessed for fetching the font data.

## Reference
https://web.dev/uses-rel-preconnect/