### PR TITLE
Create a component for modal popups

### DIFF
--- a/src/components/ModalPopup.js
+++ b/src/components/ModalPopup.js
@@ -1,0 +1,36 @@
+import {useContext} from 'react';
+import PropTypes from 'prop-types';
+
+import {NightModeContext} from 'src/context/NightModeContext';
+import {ButtonSquare} from 'src/elements/ButtonSquare';
+import DivScrim from 'src/elements/DivScrim';
+import DivPopup from 'src/elements/DivPopup';
+import SvgClose from 'src/elements/SvgClose';
+
+const ModalPopup = ({children, setModalPopupHidden}) => {
+  const nightMode = useContext(NightModeContext);
+  const handleClick = () => {
+    setModalPopupHidden(true);
+  };
+  return (
+    <DivScrim>
+      <DivPopup data-darkmode={nightMode}>
+        <ButtonSquare
+          data-darkmode={nightMode}
+          onClick={handleClick}
+          type="button"
+        >
+          <SvgClose title="Close" />
+        </ButtonSquare>
+        {children}
+      </DivPopup>
+    </DivScrim>
+  );
+};
+
+ModalPopup.propTypes = {
+  children: PropTypes.element,
+  setModalPopupHidden: PropTypes.func.isRequired,
+};
+
+export default ModalPopup;

--- a/src/components/ModalPopup.stories.js
+++ b/src/components/ModalPopup.stories.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import ModalPopup from './ModalPopup';
+
+import {NightModeContext} from 'src/context/NightModeContext';
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  title: 'ModalPopup component',
+  component: ModalPopup,
+  parameters: {
+    backgrounds: {
+      default: 'black',
+      values: [
+        {name: 'white', value: '#fff'},
+        {name: 'black', value: '#2b2b2b'},
+      ],
+    },
+  },
+};
+
+const mockContent = <p>This is a modal popup.</p>;
+
+// light mode
+function ModalPopupAtDay() {
+  return (
+    <NightModeContext.Provider value={false}>
+      <ModalPopup children={mockContent} />
+    </NightModeContext.Provider>
+  );
+}
+
+export function DefaultStyle() {
+  return <ModalPopupAtDay />;
+}
+
+// night mode
+function ModalPopupAtNight() {
+  return (
+    <NightModeContext.Provider value={true}>
+      <ModalPopup children={mockContent} />
+    </NightModeContext.Provider>
+  );
+}
+
+export function NightModeStyle() {
+  return <ModalPopupAtNight />;
+}
+NightModeStyle.parameters = {
+  backgrounds: {
+    default: 'white',
+  },
+};

--- a/src/components/ModalPopup.test.js
+++ b/src/components/ModalPopup.test.js
@@ -1,0 +1,40 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {axe} from 'jest-axe';
+
+import ModalPopup from './ModalPopup';
+
+const mockProps = {
+  setModalPopupHidden: jest.fn().mockName('setModalPopupHidden'),
+};
+
+describe('ModalPopup component', () => {
+  test('renders child elements', () => {
+    const mockContent = 'Mock content';
+    const {rerender} = render(
+      <ModalPopup {...mockProps}>
+        <p>{mockContent}</p>
+      </ModalPopup>,
+    );
+    expect(screen.getByText(mockContent)).toBeVisible();
+    const mockHeading = 'Mock heading';
+    rerender(
+      <ModalPopup {...mockProps}>
+        <h2>{mockHeading}</h2>
+      </ModalPopup>,
+    );
+    expect(screen.getByRole('heading', {name: mockHeading})).toBeVisible();
+  });
+  test('calls setModalPopupHidden(true) when the close button is clicked', () => {
+    render(<ModalPopup {...mockProps} />);
+    userEvent.click(screen.getByRole('button', {name: 'Close'}));
+    expect(mockProps.setModalPopupHidden).toHaveBeenCalledTimes(1);
+    expect(mockProps.setModalPopupHidden).toHaveBeenCalledWith(true);
+  });
+});
+
+test('Accessibility checks', async () => {
+  const {container} = render(<ModalPopup {...mockProps} />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/src/elements/Button.js
+++ b/src/elements/Button.js
@@ -1,6 +1,7 @@
 import styled, {css} from 'styled-components';
 
 import {color, dimension} from 'src/utils/designtokens';
+import {zIndex} from 'src/utils/zIndex';
 
 const resetStyle = css`
   background-color: ${color['white 0']};
@@ -20,7 +21,7 @@ const alignButtonLabel = css`
 
 const showButtonAboveMap = css`
   position: absolute;
-  z-index: 1;
+  z-index: ${zIndex.button};
 `;
 
 const positionButton = css`

--- a/src/elements/ButtonSquare.js
+++ b/src/elements/ButtonSquare.js
@@ -1,0 +1,59 @@
+import styled, {css} from 'styled-components';
+
+import {color, dimension} from 'src/utils/designtokens';
+
+const resetStyle = css`
+  background-color: ${color['white 0']};
+  border: none;
+`;
+
+const setClickableArea = css`
+  height: ${dimension.button['minimum target size 100']};
+  width: ${dimension.button['minimum target size 100']};
+`;
+
+const alignButtonLabel = css`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+`;
+
+const positionButton = css`
+  position: absolute;
+  top: ${dimension.button['minimum target size 50']};
+  right: ${dimension.button['minimum target size 50']};
+`;
+
+const setButtonLabelColor = css`
+  & svg {
+    fill: var(--button-label-color-default);
+  }
+  &:focus svg,
+  &:hover svg {
+    fill: var(--button-label-color-focus);
+  }
+  &:active svg {
+    fill: var(--button-label-color-default);
+  }
+`;
+
+const setColorScheme = css`
+  &[data-darkmode='false'] {
+    --button-label-color-default: ${color['dark-grey 100']};
+    --button-label-color-focus: ${color['black 100']};
+  }
+  &[data-darkmode='true'] {
+    --button-label-color-default: ${color['off-white 100']};
+    --button-label-color-focus: ${color['white 100']};
+  }
+`;
+
+// Define Button components
+export const ButtonSquare = styled.button`
+  ${resetStyle}
+  ${setClickableArea}
+  ${alignButtonLabel}
+  ${positionButton}
+  ${setButtonLabelColor}
+  ${setColorScheme}
+`;

--- a/src/elements/ButtonSquare.test.js
+++ b/src/elements/ButtonSquare.test.js
@@ -1,0 +1,62 @@
+// eslint-disable-next-line no-unused-vars
+import {render, screen} from '@testing-library/react';
+
+import {ButtonSquare} from './ButtonSquare';
+
+describe('ButtonSquare component', () => {
+  test('renders the UI correctly', () => {
+    const {container} = render(<ButtonSquare />);
+    expect(container).toMatchInlineSnapshot(`
+.c0 {
+  background-color: rgba(255,255,255,0);
+  border: none;
+  height: 48px;
+  width: 48px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: absolute;
+  top: 24px;
+  right: 24px;
+}
+
+.c0 svg {
+  fill: var(--button-label-color-default);
+}
+
+.c0:focus svg,
+.c0:hover svg {
+  fill: var(--button-label-color-focus);
+}
+
+.c0:active svg {
+  fill: var(--button-label-color-default);
+}
+
+.c0[data-darkmode='false'] {
+  --button-label-color-default: rgb(90,90,90);
+  --button-label-color-focus: rgb(3,3,3);
+}
+
+.c0[data-darkmode='true'] {
+  --button-label-color-default: rgb(218,218,218);
+  --button-label-color-focus: rgb(255,255,255);
+}
+
+<div>
+  <button
+    class="c0"
+  />
+</div>
+`);
+  });
+});

--- a/src/elements/DivMap.js
+++ b/src/elements/DivMap.js
@@ -1,7 +1,16 @@
 import styled from 'styled-components';
 
-const DivMap = styled.div`
+const drawMapFullscreen = `
   height: 100%;
+`;
+
+const createStackingContext = `
+  isolation: isolate;
+`; // Without stacking context, full-screen scrim won't be able to disable the clicking of Google Logo (z-index: 1000000) and buttons at the bottom-right corners (z-index: 1000001)
+
+const DivMap = styled.div`
+  ${drawMapFullscreen}
+  ${createStackingContext}
 `;
 
 export default DivMap;

--- a/src/elements/DivMap.test.js
+++ b/src/elements/DivMap.test.js
@@ -5,14 +5,15 @@ import DivMap from './DivMap';
 test('renders UI correctly', () => {
   const {container} = render(<DivMap />);
   expect(container).toMatchInlineSnapshot(`
-    .c0 {
-      height: 100%;
-    }
+.c0 {
+  height: 100%;
+  isolation: isolate;
+}
 
-    <div>
-      <div
-        class="c0"
-      />
-    </div>
-  `);
+<div>
+  <div
+    class="c0"
+  />
+</div>
+`);
 });

--- a/src/elements/DivPopup.js
+++ b/src/elements/DivPopup.js
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+// import PropTypes from 'prop-types';
+import {color} from 'src/utils/designtokens';
+import {zIndex} from 'src/utils/zIndex';
+
+const placeOverScrim = `
+  position: absolute;
+  z-index: ${zIndex.divPopup};  
+`;
+
+const dimension = {
+  'margin 66': `16px`,
+  'margin 100': `24px`,
+  'margin 133': `32px`,
+  'margin 200': `48px`,
+};
+
+const setColorScheme = `
+  &[data-darkmode='false'] {
+    --popup-background-color: ${color['white 93']};
+    --popup-shadow-color: ${color['white 63']};
+  }
+  &[data-darkmode='true'] {
+    --popup-background-color: ${color['mid-grey 80']};
+    --popup-shadow-color: ${color['mid-grey 42']};
+  }
+`;
+
+const DivPopup = styled.div`
+  ${placeOverScrim}
+  ${setColorScheme}
+  background: var(--popup-background-color);
+  box-shadow: 0 0 ${dimension['margin 66']} ${dimension['margin 66']}
+      var(--popup-shadow-color),
+    0 0 ${dimension['margin 100']} ${dimension['margin 66']}
+      var(--popup-shadow-color),
+    0 0 ${dimension['margin 133']} ${dimension['margin 66']}
+      var(--popup-shadow-color);
+  height: calc(100% - ${dimension['margin 200']});
+  text-align: center;
+  top: ${dimension['margin 100']};
+  left: ${dimension['margin 100']};
+  right: ${dimension['margin 100']};
+  bottom: ${dimension['margin 100']};
+  width: calc(100% - ${dimension['margin 200']});
+`;
+
+// DivPopup.propTypes = {};
+export default DivPopup;

--- a/src/elements/DivPopup.test.js
+++ b/src/elements/DivPopup.test.js
@@ -1,0 +1,50 @@
+// eslint-disable-next-line no-unused-vars
+import {render, screen} from '@testing-library/react';
+
+import DivPopup from './DivPopup';
+
+const mockProps = {};
+
+test('renders UI correctly', () => {
+  const {container} = render(<DivPopup {...mockProps} />);
+  expect(container).toMatchInlineSnapshot(`
+.c0 {
+  position: absolute;
+  z-index: 3;
+  background: var(--popup-background-color);
+  box-shadow: 0 0 16px 16px var(--popup-shadow-color),0 0 24px 16px var(--popup-shadow-color),0 0 32px 16px var(--popup-shadow-color);
+  height: calc(100% - 48px);
+  text-align: center;
+  top: 24px;
+  left: 24px;
+  right: 24px;
+  bottom: 24px;
+  width: calc(100% - 48px);
+}
+
+.c0[data-darkmode='false'] {
+  --popup-background-color: rgba(255,255,255,0.93);
+  --popup-shadow-color: rgba(255,255,255,0.63);
+}
+
+.c0[data-darkmode='true'] {
+  --popup-background-color: rgba(123,123,123,0.8);
+  --popup-shadow-color: rgba(123,123,123,0.42);
+}
+
+<div>
+  <div
+    class="c0"
+  />
+</div>
+`);
+});
+
+// describe('Props change style correctly', () => {
+//   test('testProp', () => {
+//     render(<DivPopup testProp data-testid="DivPopup" />);
+//     expect(screen.getByTestId('DivPopup')).toHaveStyle(
+//       `display: block`,
+//     );
+//   });
+// });

--- a/src/elements/DivScrim.js
+++ b/src/elements/DivScrim.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+// import PropTypes from 'prop-types';
+import {zIndex} from 'src/utils/zIndex';
+
+const DivScrim = styled.div`
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: ${zIndex.divScrim};
+`;
+
+// DivScrim.propTypes = {};
+export default DivScrim;

--- a/src/elements/DivScrim.test.js
+++ b/src/elements/DivScrim.test.js
@@ -1,0 +1,33 @@
+// eslint-disable-next-line no-unused-vars
+import {render, screen} from '@testing-library/react';
+
+import DivScrim from './DivScrim';
+
+const mockProps = {};
+
+test('renders UI correctly', () => {
+  const {container} = render(<DivScrim {...mockProps} />);
+  expect(container).toMatchInlineSnapshot(`
+.c0 {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 2;
+}
+
+<div>
+  <div
+    class="c0"
+  />
+</div>
+`);
+});
+
+// describe('Props change style correctly', () => {
+//   test('testProp', () => {
+//     render(<DivScrim testProp data-testid="DivScrim" />);
+//     expect(screen.getByTestId('DivScrim')).toHaveStyle(
+//       `display: block`,
+//     );
+//   });
+// });

--- a/src/elements/SvgClose.js
+++ b/src/elements/SvgClose.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+
+import {dimension} from 'src/utils/designtokens';
+
+const SvgClose = ({title}) => {
+  return (
+    <svg
+      role="img"
+      aria-labelledby="close"
+      height={dimension.button['minimum target size 75']}
+      viewBox="0 0 24 24"
+      width={dimension.button['minimum target size 75']}
+    >
+      <title id="close">{title}</title>
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z" />
+      {/* source: https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Aclose%3A */}
+    </svg>
+  );
+};
+
+SvgClose.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default SvgClose;

--- a/src/elements/SvgClose.test.js
+++ b/src/elements/SvgClose.test.js
@@ -1,0 +1,54 @@
+import {render, screen} from '@testing-library/react';
+import {axe} from 'jest-axe';
+
+import SvgClose from './SvgClose';
+
+const mockProps = {
+  title: 'Close search box',
+};
+
+test('sets the SVG image size explicitly', () => {
+  render(<SvgClose {...mockProps} />);
+  // Otherwise Safari fails to render the SVG image as a button label
+  expect(screen.getByRole('img', {name: mockProps.title})).toHaveAttribute(
+    'width',
+  );
+  expect(screen.getByRole('img', {name: mockProps.title})).toHaveAttribute(
+    'height',
+  );
+});
+
+test('renders UI correctly', () => {
+  const {container} = render(<SvgClose {...mockProps} icon="add" />);
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  <svg
+    aria-labelledby="close"
+    height="36px"
+    role="img"
+    viewBox="0 0 24 24"
+    width="36px"
+  >
+    <title
+      id="close"
+    >
+      Close search box
+    </title>
+    <path
+      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+    />
+  </svg>
+</div>
+`);
+});
+
+test('has accessible name set by the title prop', () => {
+  render(<SvgClose {...mockProps} />);
+  expect(screen.getByTitle(mockProps.title)).toBeInTheDocument();
+});
+
+test('Accessibility checks', async () => {
+  const {container} = render(<SvgClose {...mockProps} />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/src/utils/designtokens.js
+++ b/src/utils/designtokens.js
@@ -4,6 +4,7 @@ export const color = {
 
   // daytime
   'white 93': `rgba(255,255,255,0.93)`,
+  'white 63': `rgba(255,255,255,0.63)`,
   'day-light-grey 100': '#aaaaaa', // 9.03 = day-mid-grey 100 * 3
   'light-grey 100': `rgb(148, 148, 148)`, // 6.92 white 100 / 3
   'day-mid-grey 100': 'rgb(137, 137, 137)', // '#898989', // 6 = pale-cyan 100 / 1.5
@@ -20,6 +21,7 @@ export const color = {
   'off-white 100': `rgb(218,218,218)`, // 15.02 = white 100 / 1.5
   'night-light-grey 100': '#929292', // 6.74 = off-black 100 * 4.5
   'mid-grey 80': `rgba(123,123,123,0.8)`, // 4.96 = dull-orange 100
+  'mid-grey 42': `rgba(123,123,123,0.42)`,
   'night-mid-grey 100': '#757575', // 4.55 = off-black 100 * 3
   'dull-orange 100': '#ae6f2f', // 5.11 = greyish-green 100 * 1.5
   'greyish-green 100': '#4c664c', // 3.31 = greyish-cyan 100 * 1.5
@@ -70,6 +72,9 @@ export const dimension = {
     'height 25': '12px',
     'width 100': '56px',
     'width 25': '14px',
+    'minimum target size 100': '48px', // https://web.dev/accessible-tap-targets/
+    'minimum target size 75': '36px',
+    'minimum target size 50': '24px', // https://web.dev/accessible-tap-targets/
   },
   shadow: {
     offset: '0px 0px',

--- a/src/utils/zIndex.js
+++ b/src/utils/zIndex.js
@@ -1,0 +1,14 @@
+// Z-index management a la https://www.smashingmagazine.com/2021/02/css-z-index-large-projects/
+const base = 0;
+const above = 1;
+// const below = -1;
+
+const button = above + base;
+const divScrim = above + button;
+const divPopup = above + divScrim;
+
+export const zIndex = {
+  button,
+  divScrim,
+  divPopup,
+};


### PR DESCRIPTION
prepare for being used in all cases where we need a modal popup

- Create `ModalPopup` component that consists of `DivScrim`, `DivPopup`, `ButtonSquare` and `SvgClose`.
- `DivScrim` is a transparent overlay to cover the entire screen so that the pop up will be modal.
- `DivPopup` is styled like clouds, with edges shadowed in the same color as the background. It will contain text.
- `ButtonSquare` and `SvgClose` create a close button with X icon label.
- `ModalPopup` receives `setModalPopupHidden` function as a prop. This function will be executed when the user clicks the close button
- To manage the order in which different components are layered, create `utils/zIndex.js`, which manages z-index (including `Button` component) in the manner proposed by https://www.smashingmagazine.com/2021/02/css-z-index-large-projects/
- `DivMap` is styled with `isolation:isolate` so Google Maps elements won't be shown over the `DivScrim`. See https://www.joshwcomeau.com/css/stacking-contexts/