### PR TITLE
Remove button's focus style after tapped or mouse-clicked

### DIFF
--- a/src/elements/Button.js
+++ b/src/elements/Button.js
@@ -53,6 +53,9 @@ const setButtonLabelColor = css`
   &:hover svg {
     fill: var(--button-label-color-focus);
   }
+  &:focus:not(:focus-visible) svg {
+    fill: var(--button-label-color-default);
+  }
   &:active svg {
     fill: var(--button-label-color-default);
   }
@@ -62,27 +65,36 @@ const setButtonColor = css`
     fill: var(--button-color);
   }
 `;
+const buttonShadow = {
+  edge: `stroke: var(--button-outline-color);`,
+  blur: `
+    filter: drop-shadow(
+      ${dimension.shadow['offset']} ${dimension.shadow['blur layer 1']}
+        var(--button-shadow-color)
+    )
+    drop-shadow(
+      ${dimension.shadow['offset']} ${dimension.shadow['blur layer 2']}
+        var(--button-shadow-color)
+    )
+    drop-shadow(
+      ${dimension.shadow['offset']} ${dimension.shadow['blur layer 3']}
+        var(--button-shadow-color)
+    );
+  `,
+};
 const setButtonShadow = css`
   & #cloud {
-    stroke: var(--button-outline-color);
+    ${buttonShadow.edge}
   }
   & svg {
-    filter: drop-shadow(
-        ${dimension.shadow['offset']} ${dimension.shadow['blur layer 1']}
-          var(--button-shadow-color)
-      )
-      drop-shadow(
-        ${dimension.shadow['offset']} ${dimension.shadow['blur layer 2']}
-          var(--button-shadow-color)
-      )
-      drop-shadow(
-        ${dimension.shadow['offset']} ${dimension.shadow['blur layer 3']}
-          var(--button-shadow-color)
-      );
+    ${buttonShadow.blur}
   }
   &:focus #cloud,
   &:hover #cloud {
     stroke: var(--button-outline-color-focus);
+  }
+  &:focus:not(:focus-visible) #cloud {
+    ${buttonShadow.edge}
   }
   &:focus svg,
   &:hover svg {
@@ -90,6 +102,9 @@ const setButtonShadow = css`
       ${dimension.glow['offset']} var(--button-shadow-blur-radius-focus)
         var(--button-shadow-color-focus)
     );
+  }
+  &:focus:not(:focus-visible) svg {
+    ${buttonShadow.blur}
   }
   &:active svg {
     filter: none;

--- a/src/elements/Button.test.js
+++ b/src/elements/Button.test.js
@@ -57,6 +57,10 @@ describe('Button component', () => {
   fill: var(--button-label-color-focus);
 }
 
+.c0:focus:not(:focus-visible) svg {
+  fill: var(--button-label-color-default);
+}
+
 .c0:active svg {
   fill: var(--button-label-color-default);
 }
@@ -79,10 +83,19 @@ describe('Button component', () => {
   stroke: var(--button-outline-color-focus);
 }
 
+.c0:focus:not(:focus-visible) #cloud {
+  stroke: var(--button-outline-color);
+}
+
 .c0:focus svg,
 .c0:hover svg {
   -webkit-filter: drop-shadow( 0px 0px var(--button-shadow-blur-radius-focus) var(--button-shadow-color-focus) );
   filter: drop-shadow( 0px 0px var(--button-shadow-blur-radius-focus) var(--button-shadow-color-focus) );
+}
+
+.c0:focus:not(:focus-visible) svg {
+  -webkit-filter: drop-shadow( 0px 0px 1px var(--button-shadow-color) ) drop-shadow( 0px 0px 2px var(--button-shadow-color) ) drop-shadow( 0px 0px 4px var(--button-shadow-color) );
+  filter: drop-shadow( 0px 0px 1px var(--button-shadow-color) ) drop-shadow( 0px 0px 2px var(--button-shadow-color) ) drop-shadow( 0px 0px 4px var(--button-shadow-color) );
 }
 
 .c0:active svg {

--- a/src/elements/ButtonSquare.js
+++ b/src/elements/ButtonSquare.js
@@ -32,6 +32,9 @@ const setButtonLabelColor = css`
   &:hover svg {
     fill: var(--button-label-color-focus);
   }
+  &:focus:not(:focus-visible) svg {
+    fill: var(--button-label-color-default);
+  }
   &:active svg {
     fill: var(--button-label-color-default);
   }

--- a/src/elements/ButtonSquare.test.js
+++ b/src/elements/ButtonSquare.test.js
@@ -38,6 +38,10 @@ describe('ButtonSquare component', () => {
   fill: var(--button-label-color-focus);
 }
 
+.c0:focus:not(:focus-visible) svg {
+  fill: var(--button-label-color-default);
+}
+
 .c0:active svg {
   fill: var(--button-label-color-default);
 }


### PR DESCRIPTION
avoid confusing users about button's state after tapped/mouse-clicked

close #98