### PR TITLE
ci(npm): use Node 16 for running tests on CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
       - name: 'Install Node'
         uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '16'
           cache: 'npm'
       - name: 'Install repo'
         run: npm install


### PR DESCRIPTION
The `package-lock.json` is now created with NPM 7 (`lockfileVersion@2). The `setup-node@v2` uses NPM 7 only if `node-version` is set to be `15` (source: https://github.com/actions/setup-node/issues/213)