### PR TITLE
build(cypress-testing-library): upgrade to v8.0.3 to work with Cypress 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@storybook/addon-essentials": "6.5.12",
         "@storybook/addon-links": "6.3.7",
         "@storybook/react": "6.5.12",
-        "@testing-library/cypress": "^8.0.2",
+        "@testing-library/cypress": "8.0.3",
         "@testing-library/jest-dom": "^5.11.6",
         "@testing-library/react": "^11.2.2",
         "@testing-library/react-hooks": "8.0.1",
@@ -13249,9 +13249,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@testing-library/cypress": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.2.tgz",
-      "integrity": "sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.3.tgz",
+      "integrity": "sha512-nY2YaSbmuPo5k6kL0iLj/pGPPfka3iwb3kpTx8QN/vOCns92Saz9wfACqB8FJzcR7+lfA4d5HUOWqmTddBzczg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.14.6",
@@ -13262,7 +13262,7 @@
         "npm": ">=6"
       },
       "peerDependencies": {
-        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@testing-library/cypress/node_modules/@jest/types": {
@@ -53288,9 +53288,9 @@
       }
     },
     "@testing-library/cypress": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.2.tgz",
-      "integrity": "sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.3.tgz",
+      "integrity": "sha512-nY2YaSbmuPo5k6kL0iLj/pGPPfka3iwb3kpTx8QN/vOCns92Saz9wfACqB8FJzcR7+lfA4d5HUOWqmTddBzczg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.14.6",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@storybook/addon-essentials": "6.5.12",
     "@storybook/addon-links": "6.3.7",
     "@storybook/react": "6.5.12",
-    "@testing-library/cypress": "^8.0.2",
+    "@testing-library/cypress": "^8.0.3",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/react-hooks": "8.0.1",


### PR DESCRIPTION
Version 8.0.2 cannot use Cypress 10, causing error when being built with Node 16 on GitHub Actions
and DigitalOcean.
